### PR TITLE
Update readme with team02 dokku dev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# STARTER-team02
+team02-s24-4pm-3
 
 Instructions: <https://ucsb-cs156.github.io/s24/lab/team02.html>
 
-TODO: change heading above to your repo name, e.g. `# team02-s24-6pm-4`
-
-TODO: Add a link to the deployed Dokku app for your team here, e.g.
-
 Deployments:
 
-* Prod: <https://team02.dokku-17.cs.ucsb.edu>
-* QA: <https://team02-qa.dokku-17.cs.ucsb.edu>
+* Prod: [https://team02.dokku-03.cs.ucsb.edu/](https://team02.dokku-03.cs.ucsb.edu/)
+* QA: <Todo>
 
 # Setup before running application
 


### PR DESCRIPTION
Add team development dokku instance link to README
- Team members along with admin should be able to log on to the app

Closes #3 