### PR TITLE
Help Request Controller (with GET and POST) and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -1,0 +1,56 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+public class HelpRequestsController {
+
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @Operation(summary = "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        return helpRequestRepository.findAll();
+    }
+
+    @Operation(summary = "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="teamId") @RequestParam String teamId,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="requestTime", description = "in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="solved") @RequestParam boolean solved
+    ) throws JsonProcessingException {
+        var helpRequest = HelpRequest.builder()
+                .requesterEmail(requesterEmail)
+                .teamId(teamId)
+                .tableOrBreakoutRoom(tableOrBreakoutRoom)
+                .requestTime(requestTime)
+                .explanation(explanation)
+                .solved(solved)
+                .build();
+        return helpRequestRepository.save(helpRequest);
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String requesterEmail;
+    private String teamId;
+    private String tableOrBreakoutRoom;
+    private LocalDateTime requestTime;
+    private String explanation;
+    private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,86 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "HelpRequest-1",
+        "author": "EricW",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "HELPREQUESTS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "CONSTRAINT_8"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUESTER_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TEAM_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_OR_BREAKOUT_ROOM",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUEST_TIME",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "LOCAL_DATE_TIME",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPLANATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SOLVED",
+                    "type": "BOOLEAN"
+                  }
+                }
+              ],
+              "tableName": "HELPREQUESTS"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -1,0 +1,148 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = HelpRequestsController.class)
+@Import(TestConfig.class)
+public class HelpRequestsControllerTests extends ControllerTestCase {
+    @MockBean
+    HelpRequestRepository helpRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Begin tests for GET /api/helprequests/all
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_helprequests() throws Exception {
+        // arrange
+
+
+        var helpRequest1 = HelpRequest.builder()
+                .requesterEmail("ewetzel@ucsb.edu")
+                .requestTime(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .explanation("I can't find my glasses")
+                .tableOrBreakoutRoom("table 3")
+                .teamId("s24-4pm-3")
+                .solved(false)
+                .build();
+
+        var helpRequest2 = HelpRequest.builder()
+                .requesterEmail("pconrad@ucsb.edu")
+                .requestTime(LocalDateTime.parse("2022-02-03T00:00:00"))
+                .explanation("I am lost in Lisbon, Portugal")
+                .tableOrBreakoutRoom("breakout room 4")
+                .teamId("s24-4pm-4")
+                .solved(false)
+                .build();
+
+
+
+        ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>(List.of(helpRequest1, helpRequest2));
+
+        when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(helpRequestRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // End tests for GET /api/helprequests/all
+
+    // Begin tests for POST /api/helprequests/post
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/helprequests/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/helprequests/post"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+        // arrange
+
+        var helpRequest = HelpRequest.builder()
+                .requesterEmail("ewetzel@ucsb.edu")
+                .requestTime(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .explanation("I can't find my glasses")
+                .tableOrBreakoutRoom("table 3")
+                .teamId("s24-4pm-3")
+                .solved(false)
+                .build();
+
+        when(helpRequestRepository.save(eq(helpRequest))).thenReturn(helpRequest);
+
+        // act
+        String requestUrl = "/api/helprequests/post?" +
+                "requesterEmail=ewetzel@ucsb.edu" +
+                "&teamId=s24-4pm-3" +
+                "&requestTime=2022-01-03T00:00:00" +
+                "&explanation=I can't find my glasses" +
+                "&tableOrBreakoutRoom=table 3" +
+                "&solved=false";
+        MvcResult response = mockMvc.perform(
+                        post(requestUrl)
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(helpRequestRepository, times(1)).save(helpRequest);
+        String expectedJson = mapper.writeValueAsString(helpRequest);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // End tests for POST /api/helprequests/post
+
+
+}


### PR DESCRIPTION
Closes #33. Marked as draft until #47 is merged first.

In this PR we implement the HelpRequest controller with the GET /api/helprequests/all and POST /api/helprequests/post methods.

Dev deployment here: https://team02-ericpretzel-dev.dokku-03.cs.ucsb.edu/