### PR TITLE
HelpRequest DELETE endpoint and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -82,4 +82,14 @@ public class HelpRequestsController extends ApiController {
         return helpRequest;
     }
 
+    @Operation(summary = "Delete a help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        var helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
 }


### PR DESCRIPTION
Closes #36.

 Implements DELETE endpoint for helprequest controller with tests.

Dev deployment here: https://team02-ericpretzel-dev.dokku-03.cs.ucsb.edu/